### PR TITLE
Carousel control color

### DIFF
--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -14,3 +14,9 @@ body {
     padding-bottom: 20px;
   }
 }
+
+$vivid-blue: #007bff;
+$carousel-control-color: $vivid-blue;
+$carousel-indicator-active-bg: $vivid-blue;
+
+@import "~bootstrap/scss/bootstrap";

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -15,6 +15,7 @@ body {
   }
 }
 
+// Use same color as h5 defined in `../components/section/Access.vue`
 $vivid-blue: #007bff;
 $carousel-control-color: $vivid-blue;
 $carousel-indicator-active-bg: $vivid-blue;

--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,6 @@ import MenuSlide from '~/components/carousel/MenuSlide.vue'
 import SocialLinkButton from '~/components/footer/SocialLinkButton.vue'
 
 import BootstrapVue from 'bootstrap-vue'
-import 'bootstrap/dist/css/bootstrap.css'
 import 'bootstrap-vue/dist/bootstrap-vue.css'
 
 export default function(Vue) {


### PR DESCRIPTION
![porto_after](https://user-images.githubusercontent.com/5971361/66265246-51dc5c80-e84e-11e9-9180-d339412b4d94.png)

カルーセルのコントロールとインジケータが画像と同系統の白色で見づらかったので、画面中で利用されているのと同じ青色を利用するよう修正しました。