### PR TITLE
fix(seo): 本番URLをリポジトリ内定数で管理し、CF_PAGES_URLのハッシュ付きURL問題を修正

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,10 +2,14 @@
 import { defineConfig, envField } from 'astro/config';
 import partytown from '@astrojs/partytown';
 import sitemap from '@astrojs/sitemap';
+import { SITE_URL } from './src/consts';
+
+// 本番ブランチでは定数の正規URLを使用し、プレビュー環境ではCF_PAGES_URLを使用する
+const isProduction = !process.env.CF_PAGES_BRANCH || process.env.CF_PAGES_BRANCH === 'master';
 
 // https://astro.build/config
 export default defineConfig({
-  site: process.env.CF_PAGES_URL || 'https://trattoria-e-bar-porto-yamanashi.pages.dev',
+  site: isProduction ? SITE_URL : process.env.CF_PAGES_URL,
   env: {
     schema: {
       PUBLIC_GA_ID: envField.string({

--- a/docs/references/astro-cloudflare-pages-seo/guidelines.md
+++ b/docs/references/astro-cloudflare-pages-seo/guidelines.md
@@ -7,29 +7,32 @@
 ### 重要: `CF_PAGES_URL` は本番URLではない
 Cloudflare Pages が自動注入する `CF_PAGES_URL` は、本番デプロイであっても `https://<commit-hash>.<project>.pages.dev` 形式のデプロイ固有URLが設定される。正規の本番URL（`https://<project>.pages.dev` や独自ドメイン）は**自動提供されない**。
 
-### 推奨: カスタム環境変数 `SITE_URL` を使う
-Cloudflare Pages のダッシュボード（Settings > Environment variables）で、**Productionにのみ** `SITE_URL` 環境変数を設定する。
+### 推奨: リポジトリ定数 `SITE_URL` を使う
+`src/consts.ts` に本番用の正規URLを定数として定義し、`astro.config.mjs` から import する。`CF_PAGES_BRANCH` により本番 / プレビューを判定する。
 
+```typescript
+// src/consts.ts
+export const SITE_URL = 'https://trattoria-e-bar-porto-yamanashi.pages.dev';
 ```
-SITE_URL = https://trattoria-e-bar-porto-yamanashi.pages.dev
-```
-
-`astro.config.mjs` では以下のように優先度を設定する:
 
 ```javascript
 // astro.config.mjs
+import { SITE_URL } from './src/consts';
+
+// 本番ブランチでは定数の正規URLを使用し、プレビュー環境ではCF_PAGES_URLを使用する
+const isProduction = !process.env.CF_PAGES_BRANCH || process.env.CF_PAGES_BRANCH === 'master';
+
 export default defineConfig({
-  // 1. SITE_URL（ダッシュボードで設定、本番用）を最優先
-  // 2. CF_PAGES_URL（プレビュー環境用）にフォールバック
-  // 3. ローカル開発用のデフォルト
-  site: process.env.SITE_URL || process.env.CF_PAGES_URL || 'http://localhost:4321',
+  // 本番ブランチではリポジトリ定数 SITE_URL、プレビューでは CF_PAGES_URL を使用
+  site: isProduction ? SITE_URL : process.env.CF_PAGES_URL,
 });
 ```
 
 この構成により:
-- **本番デプロイ**: `SITE_URL` が使われ、正規URLでサイトマップ等が生成される
+- **本番デプロイ**: `SITE_URL` 定数が使われ、正規URLでサイトマップ等が生成される
 - **プレビュー環境**: `CF_PAGES_URL` が使われ、プレビュー固有のURLで確認できる
-- **ローカル開発**: `http://localhost:4321` が使われる
+- **ローカル開発**: `CF_PAGES_BRANCH` が未設定のため本番扱いとなり、`SITE_URL` が使われる
+- **プラットフォーム移行時**: `src/consts.ts` の定数を1箇所変更するだけで対応可能
 
 ## 2. robots.txt の動的生成
 `public/robots.txt` は静的アセットのため環境変数をパースできない。Astroのエンドポイント機能を利用し、ビルド時にその時の `site`（つまり環境に応じたURL）を活用して出力する。

--- a/docs/references/astro-cloudflare-pages-seo/guidelines.md
+++ b/docs/references/astro-cloudflare-pages-seo/guidelines.md
@@ -3,26 +3,46 @@
 本ガイドラインは、AstroプロジェクトをCloudflare Pagesにデプロイする際の、動的なURL生成（SEO対策）のベストプラクティスを定めたものです。
 
 ## 1. サイト基本URLの動的設定
-Cloudflare Pagesは、本番環境とプレビュー環境（ブランチデプロイ）で異なるURLを自動生成します。OGP画像やサイトマップのURLを各環境に自動適応させるため、`astro.config.mjs` の `site` 設定は静的な文字列ではなく、環境変数を参照します。
+
+### 重要: `CF_PAGES_URL` は本番URLではない
+Cloudflare Pages が自動注入する `CF_PAGES_URL` は、本番デプロイであっても `https://<commit-hash>.<project>.pages.dev` 形式のデプロイ固有URLが設定される。正規の本番URL（`https://<project>.pages.dev` や独自ドメイン）は**自動提供されない**。
+
+### 推奨: カスタム環境変数 `SITE_URL` を使う
+Cloudflare Pages のダッシュボード（Settings > Environment variables）で、**Productionにのみ** `SITE_URL` 環境変数を設定する。
+
+```
+SITE_URL = https://trattoria-e-bar-porto-yamanashi.pages.dev
+```
+
+`astro.config.mjs` では以下のように優先度を設定する:
 
 ```javascript
 // astro.config.mjs
 export default defineConfig({
-  // 独自ドメインがある場合は CUSTOM_DOMAIN を優先し、なければ CF_PAGES_URL を使用
-  site: process.env.CUSTOM_DOMAIN || process.env.CF_PAGES_URL || 'http://localhost:4321',
+  // 1. SITE_URL（ダッシュボードで設定、本番用）を最優先
+  // 2. CF_PAGES_URL（プレビュー環境用）にフォールバック
+  // 3. ローカル開発用のデフォルト
+  site: process.env.SITE_URL || process.env.CF_PAGES_URL || 'http://localhost:4321',
 });
 ```
 
-*※ `CF_PAGES_URL` はCloudflareビルド時に自動付与されます。独自ドメインを導入した場合は、Pagesのダッシュボードから `CUSTOM_DOMAIN` 環境変数を手動で設定してください。*
+この構成により:
+- **本番デプロイ**: `SITE_URL` が使われ、正規URLでサイトマップ等が生成される
+- **プレビュー環境**: `CF_PAGES_URL` が使われ、プレビュー固有のURLで確認できる
+- **ローカル開発**: `http://localhost:4321` が使われる
 
 ## 2. robots.txt の動的生成
-`public/robots.txt` は静的アセットのため環境変数をパースできません。Astroのエンドポイント機能を利用し、ビルド時にその時の `site`（つまり環境に応じたURL）を活用して出力するようにします。
+`public/robots.txt` は静的アセットのため環境変数をパースできない。Astroのエンドポイント機能を利用し、ビルド時にその時の `site`（つまり環境に応じたURL）を活用して出力する。
 
 ```typescript
 // src/pages/robots.txt.ts
 import type { APIRoute } from 'astro';
 
 export const GET: APIRoute = ({ site }) => {
+  if (!site) {
+    return new Response('Sitemap site URL is not configured', { status: 500 });
+  }
+
   const robotsTxt = `
 User-agent: *
 Allow: /
@@ -36,17 +56,15 @@ Sitemap: ${new URL('sitemap-index.xml', site).href}
 ```
 
 ## 3. SEOコンポーネント（JSON-LD等）での活用
-`Astro.site` グローバル変数は `astro.config.mjs` で定義された `site` を引き継ぎます。
-メタタグ構築やJSON-LDなどに絶対URLが必要な場合は、これを利用して生成します。
+`Astro.site` グローバル変数は `astro.config.mjs` で定義された `site` を引き継ぐ。
+メタタグ構築やJSON-LDなどに絶対URLが必要な場合は、これを利用して生成する。
 
 ```astro
 // Layout.astro 等
-const siteURL = Astro.site;
+const siteURL = Astro.site!;
 const ogImageURL = new URL('/ogpimg.jpg', siteURL);
 
 // JSON-LD内で活用
 "image": ogImageURL.toString(),
 "url": siteURL.toString(),
 ```
-
-このアプローチにより、「プレビュー環境ではプレビュー用の絶対URL」「本番環境では本番用の絶対URL」が正しく生成され、検証の容易さとSEOの正確性の両立が担保されます。

--- a/docs/research/2026-04-25-cf-pages-production-url-env.md
+++ b/docs/research/2026-04-25-cf-pages-production-url-env.md
@@ -54,7 +54,24 @@ site: process.env.SITE_URL || process.env.CF_PAGES_URL || 'http://localhost:4321
 - [Cloudflare Pages Build Configuration - Environment variables](https://developers.cloudflare.com/pages/configuration/build-configuration/#environment-variables)（公式ドキュメント、最終更新: 2026-04-21）
 
 ## 推奨事項
-本プロジェクトでは**パターン2（カスタム環境変数 `SITE_URL`）**を推奨する。理由は以下の通り。
-1. コードからURLのハードコードを完全に排除できる
-2. 将来の独自ドメイン導入時にCloudflareダッシュボード上の設定変更のみで対応可能
-3. Productionにのみ設定すれば、プレビュー環境では自動的に `CF_PAGES_URL` にフォールバックする
+本プロジェクトでは**パターン1のバリアント（リポジトリ定数 + `CF_PAGES_BRANCH` 分岐）**を採用した。
+
+### 採用方式
+`src/consts.ts` に本番URLを定数として定義し、`astro.config.mjs` で `CF_PAGES_BRANCH` を用いて本番/プレビューを判定する。
+
+```javascript
+// src/consts.ts
+export const SITE_URL = 'https://trattoria-e-bar-porto-yamanashi.pages.dev';
+
+// astro.config.mjs
+import { SITE_URL } from './src/consts';
+const isProduction = !process.env.CF_PAGES_BRANCH || process.env.CF_PAGES_BRANCH === 'master';
+site: isProduction ? SITE_URL : process.env.CF_PAGES_URL,
+```
+
+### 採用理由
+1. プラットフォーム移行時に `src/consts.ts` の定数を1箇所変更するだけで済む
+2. Cloudflareダッシュボードへの依存を避け、リポジトリ内で設定を完結できる
+3. コードレビューでURL変更を追跡可能
+
+> **注**: パターン2（ダッシュボードでのカスタム環境変数）は、コード変更なしでURLを変更できるメリットがあるため、比較資料として上記に残している。

--- a/docs/research/2026-04-25-cf-pages-production-url-env.md
+++ b/docs/research/2026-04-25-cf-pages-production-url-env.md
@@ -1,0 +1,60 @@
+---
+title: Cloudflare Pages ビルド時環境変数に本番URLは存在するか
+date: 2026-04-25
+reliability: High (Cloudflare公式ドキュメント直接確認)
+depth: Deep & Narrow
+---
+
+## 調査課題
+Cloudflare Pages のビルド時に自動注入されるシステム環境変数の中に、プレビューURLではなく「本番URL（正規ドメイン）」を提供するものが存在するか。
+
+## 結論
+**本番URLを直接提供するシステム環境変数は存在しない。**
+
+## 調査結果
+
+### Cloudflare Pages が自動注入するシステム環境変数（全5つ）
+
+公式ドキュメント（https://developers.cloudflare.com/pages/configuration/build-configuration/#environment-variables）に記載されている、ビルド時に自動注入されるシステム環境変数は以下の5つのみである。
+
+| 環境変数名 | 値 | 備考 |
+|---|---|---|
+| `CI` | `true` | CI環境であることを示すフラグ |
+| `CF_PAGES` | `1` | Cloudflare Pages上で動作していることを示すフラグ |
+| `CF_PAGES_COMMIT_SHA` | `<sha1-hash>` | 現在のコミットのSHAハッシュ |
+| `CF_PAGES_BRANCH` | `<branch-name>` | 現在ビルドされているブランチ名（例: `master`, `feature/xxx`） |
+| `CF_PAGES_URL` | `<url-of-current-deployment>` | **現在のデプロイメントのURL**（コミットハッシュ付きのプレビューURL） |
+
+### `CF_PAGES_URL` の挙動
+- 本番デプロイであっても `https://<commit-hash>.<project>.pages.dev` 形式のURLが設定される
+- `https://<project>.pages.dev` という正規の本番URLは**提供されない**
+- 独自ドメインが設定されている場合でも、その独自ドメインのURLは**提供されない**
+
+### 推奨される対応パターン
+Cloudflare公式およびコミュニティのベストプラクティスとして、以下の2つの方法が推奨されている。
+
+#### パターン1: `CF_PAGES_BRANCH` で分岐する
+```javascript
+site: process.env.CF_PAGES_BRANCH === 'master'
+  ? 'https://trattoria-e-bar-porto-yamanashi.pages.dev'
+  : (process.env.CF_PAGES_URL || 'http://localhost:4321'),
+```
+- メリット: Cloudflare側で追加の環境変数設定が不要
+- デメリット: 本番URLのハードコードが残る
+
+#### パターン2: ダッシュボードでカスタム環境変数を設定する
+Cloudflare Pages のダッシュボード（Settings > Environment variables）から、Productionにのみ `SITE_URL` 等のカスタム環境変数を手動で設定し、それを優先的に参照する。
+```javascript
+site: process.env.SITE_URL || process.env.CF_PAGES_URL || 'http://localhost:4321',
+```
+- メリット: コードにURLをハードコードしなくてよい。独自ドメイン導入時も設定変更のみで対応可能
+- デメリット: ダッシュボードでの初期設定が必要
+
+## 情報源
+- [Cloudflare Pages Build Configuration - Environment variables](https://developers.cloudflare.com/pages/configuration/build-configuration/#environment-variables)（公式ドキュメント、最終更新: 2026-04-21）
+
+## 推奨事項
+本プロジェクトでは**パターン2（カスタム環境変数 `SITE_URL`）**を推奨する。理由は以下の通り。
+1. コードからURLのハードコードを完全に排除できる
+2. 将来の独自ドメイン導入時にCloudflareダッシュボード上の設定変更のみで対応可能
+3. Productionにのみ設定すれば、プレビュー環境では自動的に `CF_PAGES_URL` にフォールバックする

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,4 +1,5 @@
 ---
+import { SITE_URL } from '../consts';
 const year = new Date().getFullYear();
 ---
 
@@ -10,12 +11,12 @@ const year = new Date().getFullYear();
         </div>
         <div class="footer-links">
             <a
-                href="https://twitter.com/intent/tweet?url=https://trattoria-e-bar-porto-yamanashi.pages.dev/&text=山梨県にある北イタリア料理店（レストラン＆バー）です！"
+                href={`https://twitter.com/intent/tweet?url=${SITE_URL}/&text=山梨県にある北イタリア料理店（レストラン＆バー）です！`}
                 target="_blank"
                 rel="noopener noreferrer">Share on Twitter</a
             >
             <a
-                href="https://www.facebook.com/sharer/sharer.php?u=https://trattoria-e-bar-porto-yamanashi.pages.dev/"
+                href={`https://www.facebook.com/sharer/sharer.php?u=${SITE_URL}/`}
                 target="_blank"
                 rel="noopener noreferrer">Share on Facebook</a
             >

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,0 +1,2 @@
+/** サイトの正規URL（本番ドメイン） */
+export const SITE_URL = 'https://trattoria-e-bar-porto-yamanashi.pages.dev';


### PR DESCRIPTION
## 背景・問題
前回のSEO対策PR (#246) で `astro.config.mjs` の `site` に `CF_PAGES_URL` を使用していましたが、Cloudflare Pagesではこの環境変数が**本番デプロイでもコミットハッシュ付きのURL**（`https://<hash>.<project>.pages.dev`）を返すことが判明しました。

その結果、本番環境の `robots.txt` や `sitemap.xml` にハッシュ付きURLが出力され、SEO上の問題が発生していました。

## 変更内容
- `src/consts.ts` を新規作成し、本番URLを**リポジトリ内の定数 (`SITE_URL`)** として一元管理
- `astro.config.mjs` で `CF_PAGES_BRANCH` を用いてブランチ判定を行い、本番ブランチでは定数URL、プレビュー環境では `CF_PAGES_URL` を使用するように修正
- ガイドライン・調査ドキュメントを更新

## 設計判断
- Cloudflareダッシュボードの環境変数ではなく、リポジトリ内定数とした理由: **プラットフォーム移行時にコード内の定数を変更するだけで済む**ため
- 公式ドキュメントを調査した結果、Cloudflare Pagesには本番URLを提供するシステム環境変数は存在しないことを確認済み

## 検証
- `pnpm run build` でビルド成功を確認
- ビルド後の `dist/robots.txt` および `dist/sitemap-0.xml` に正規URLが出力されることを確認
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zakizaki-ri9/gridsome-trattoria-site/pull/247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Site now uses production-specific URL for production deployments while automatically using preview URLs for staging environments.

* **Documentation**
  * Updated configuration guidelines for environment-specific URL handling.
  * Added research documentation on Cloudflare Pages environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->